### PR TITLE
Fix grapesjs init in default template

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,15 +24,17 @@
 
 
     <script type="text/javascript">
-      window.editor = grapesjs.init({
-        height: '100%',
-        container: '#gjs',
-        showOffsets: 1,
-        noticeOnUnload: 0,
-        storageManager: false,
-        fromElement: true,
-        plugins: ['<%= name %>'],
-      });
+      window.onload = () => {
+        window.editor = grapesjs.init({
+          height: '100%',
+          container: '#gjs',
+          showOffsets: 1,
+          noticeOnUnload: 0,
+          storageManager: false,
+          fromElement: true,
+          plugins: ['<%= name %>'],
+        });
+      }
     </script>
   </body>
 </html>


### PR DESCRIPTION
Hi @artf 
I always have this issue when starting a plugin where it is not found at startup
I need to init grapesjs after the doc is fully loaded
Feel free to trash this PR if it is not useful
Thank you!