### PR TITLE
Update README: Linting fixes and content updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,12 @@
 
 ![grapesjs-cli](https://user-images.githubusercontent.com/11614725/67523496-0ed41300-f6af-11e9-9850-7175355f2946.jpg)
 
-
 A simple CLI library for helping in GrapesJS plugin development.
 
 The goal of this package is to avoid the hassle of setting up all the dependencies and configurations for the plugin development by centralizing and speeding up the necessary steps during the process.
 
 * Fast project scaffolding
 * No need to touch Babel and Webpack configurations
-
-
-
-
 
 ## Plugin from 0 to 100
 
@@ -47,7 +42,6 @@ You can also skip all the questions with `-y` option or pass all the answers via
 npx grapesjs-cli init -y --user=YOUR-GITHUB-USERNAME
 ```
 
-
 * The command will scaffold the `src` directory and a bunch of other files inside your project. The `src/index.js` will be the entry point of your plugin. Before starting developing your plugin run the development server and open the printed URL (eg. the default is http://localhost:8080)
 
 ```sh
@@ -75,15 +69,12 @@ grapesjs-cli build
 * Before publishing your package remember to complete your README.md file with all the available options, components, blocks and so on.
 For a better user engagement create a simple live demo by using services like [JSFiddle](https://jsfiddle.net) [CodeSandbox](https://codesandbox.io) [CodePen](https://codepen.io) and link it in your README. To help you in this process we'll print all the necessary HTML/CSS/JS in your README, so it will be just a matter of copy-pasting on some of those services.
 
-
-
-
-
 ## Customization
 
 ### Customize webpack config
 
 If you need to customize the webpack configuration, you can create `webpack.config.js` file in the root dir of your project and export a function, which should return the new configuration object. Check the example below.
+
 ```js
 // YOUR-PROJECT-DIR/webpack.config.js
 
@@ -100,8 +91,6 @@ export default ({ config }) => {
     };
 }
 ```
-
-
 
 ## Generic CLI usage
 
@@ -122,9 +111,6 @@ Run the command
 ```sh
 grapesjs-cli COMMAND --OPT1 --OPT2=VALUE
 ```
-
-
-
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ npx grapesjs-cli serve --devServer='{"https": true}'
 * Once the development is finished you can build your plugin and generate the minified file ready for production
 
 ```sh
-grapesjs-cli build
+npx grapesjs-cli build
 ```
 
 * Before publishing your package remember to complete your README.md file with all the available options, components, blocks and so on.

--- a/src/template/README.md
+++ b/src/template/README.md
@@ -1,11 +1,15 @@
 # <%= name %>
 
-[DEMO](##)
-> **Provide a live demo of your plugin**
-For a better user engagement create a simple live demo by using services like [JSFiddle](https://jsfiddle.net) [CodeSandbox](https://codesandbox.io) [CodePen](https://codepen.io) and link it here in your README (attaching a screenshot/gif will also be a plus).
-To help you in this process here below you will find the necessary HTML/CSS/JS, so it just a matter of copy-pasting on some of those services. After that delete this part and update the link above
+## Live Demo
+
+> **Show a live example of your plugin**
+
+To make your plugin more engaging, create a simple live demo using online tools like [JSFiddle](https://jsfiddle.net), [CodeSandbox](https://codesandbox.io), or [CodePen](https://codepen.io). Include the demo link in your README. Adding a screenshot or GIF of the demo is a bonus.
+
+Below, you'll find the necessary HTML, CSS, and JavaScript. Copy and paste this code into one of the tools mentioned. Once you're done, delete this section and update the link at the top with your demo.
 
 ### HTML
+
 ```html
 <link href="https://unpkg.com/grapesjs/dist/css/grapes.min.css" rel="stylesheet">
 <script src="https://unpkg.com/grapesjs"></script>
@@ -15,9 +19,10 @@ To help you in this process here below you will find the necessary HTML/CSS/JS, 
 ```
 
 ### JS
+
 ```js
 const editor = grapesjs.init({
-	container: '#gjs',
+ container: '#gjs',
   height: '100%',
   fromElement: true,
   storageManager: false,
@@ -26,6 +31,7 @@ const editor = grapesjs.init({
 ```
 
 ### CSS
+
 ```css
 body, html {
   margin: 0;
@@ -33,28 +39,23 @@ body, html {
 }
 ```
 
-
 ## Summary
 
 * Plugin name: `<%= rName %>`
 * Components
-    * `component-id-1`
-    * `component-id-2`
-    * ...
+  * `component-id-1`
+  * `component-id-2`
+  * ...
 * Blocks
-    * `block-id-1`
-    * `block-id-2`
-    * ...
-
-
+  * `block-id-1`
+  * `block-id-2`
+  * ...
 
 ## Options
 
 | Option | Description | Default |
-|-|-|-
+|-|-|-|
 | `option1` | Description option | `default value` |
-
-
 
 ## Download
 
@@ -70,6 +71,7 @@ body, html {
 ## Usage
 
 Directly in the browser
+
 ```html
 <link href="https://unpkg.com/grapesjs/dist/css/grapes.min.css" rel="stylesheet"/>
 <script src="https://unpkg.com/grapesjs"></script>
@@ -90,6 +92,7 @@ Directly in the browser
 ```
 
 Modern javascript
+
 ```js
 import grapesjs from 'grapesjs';
 import plugin from '<%= rName %>';
@@ -109,8 +112,6 @@ const editor = grapesjs.init({
 });
 ```
 
-
-
 ## Development
 
 Clone the repository
@@ -123,22 +124,20 @@ $ cd <%= rName %>
 Install dependencies
 
 ```sh
-$ npm i
+npm i
 ```
 
 Start the dev server
 
 ```sh
-$ npm start
+npm start
 ```
 
 Build the source
 
 ```sh
-$ npm run build
+npm run build
 ```
-
-
 
 ## License
 


### PR DESCRIPTION
- Fix markdownlint rule violations in the README file.
  - Remove `$` sign for easily copying the commands
- Rewriting certain sections of the README.
  - In the template README